### PR TITLE
Added emojies to distinguish consolelogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "watch": "nodemon ./bin/www",
-    "start": "concurrently \"npm run watch\" \"npm run assets\"",
+    "start": "concurrently \"npm run watch\" \"npm run assets\" --names \"🖥,📦\"",
     "assets": "webpack"
   },
   "dependencies": {


### PR DESCRIPTION
This PR adds emojis before console logs in the terminal to easily distinguish between node and webpack logs. 

🖥: nodemon/express server 
📦: webpack 

![2017-12-13 22-52-39-jf60r](https://user-images.githubusercontent.com/14366097/33974934-45592e56-e059-11e7-9886-d75d403abaca.png)
