### PR TITLE
make email the username for passport-localmongoose

### DIFF
--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -1,7 +1,7 @@
 const mongoose = require("mongoose");
 const Admin = mongoose.model("Admin");
 const promisify = require("es6-promisify");
-const { check, checkBody } = require("express-validator/check");
+const { check, validationResult } = require("express-validator/check");
 const { sanitizeBody } = require("express-validator/filter");
 
 exports.loginForm = (req, res) => {
@@ -14,42 +14,25 @@ exports.registerForm = (req, res) => {
 
 // the methods on the req come from: https://github.com/ctavan/express-validator
 // these methods help us quickly validate our new user
-exports.registerAdmin = (req, res, next) => {
+exports.validateAdmin = (req, res, next) => {
   console.log(req.body);
-  //sanitizeBody("name");
-  // req.sanitizeBody("name");
-  // // See: https://github.com/ctavan/express-validator#usage
-  // //req.body.check("email", "Please provide a name").isEmail();
-  // req.check("name").notEmpty();
-  //check("name", "Please provide your name").notEmpty();
-  // req.checkBody("email", "Email provided is not valid").isEmail();
-  // req.sanitizeBody("email").normalizeEmail({
-  //   gmail_remove_dots: false,
-  //   remove_extension: false,
-  //   gmail_remove_subdomain: false
-  // });
-  // req.checkBody("password", "Password cannot be blank").notEmpty();
-  // req
-  //   .checkBody("password-confirm", "Please confirm your password")
-  //   .notEmpty()
-  //   .equals(req.body.password);
-  // // See: https://github.com/ctavan/express-validator#reqvalidationerrorsmapped
-  // const errors = req.validationErrors;
-  // if (errors) {
-  //   req.render(errors);
+  // check('name', 'You must have a name').isLength({ min: 1 });
+  // const errors = validationResult(req);
+  // if (!errors.isEmpty()) {
+  //   console.log('Logged errors: ', errors);
+  //   res.send(errors);
   // }
-  // console.log("registerAdmin runs");
   next();
 };
 
 exports.register = async (req, res, next) => {
   const admin = new Admin({
-    email: req.body.email,
+    // Passing the email in as the user name fixed out problem
+    username: req.body.email,
     name: req.body.name,
-    username: req.body.username
+    email: req.body.email
   });
   const register = promisify(Admin.register, Admin);
   await register(admin, req.body.password);
-  // next();
-  res.redirect("/admin");
+  res.send('it works!!!');
 };

--- a/models/Admin.js
+++ b/models/Admin.js
@@ -11,19 +11,19 @@ const adminSchema = new mongoose.Schema({
     unique: true,
     lowercase: true,
     trim: true,
-    //validate: [validator.isEmail, "Invalid Email Address"],
+    validate: [validator.isEmail, "Invalid Email Address"],
     required: "Please Supply an email address"
   },
   name: {
     type: String,
     required: "Please supply a name",
     trim: true
-  },
-  username: {
-    type: String,
-    required: "Please supply a username",
-    trim: true
   }
+  // username: {
+  //   type: String,
+  //   required: "Please supply a username",
+  //   trim: true
+  // }
 });
 
 adminSchema.plugin(passportLocalMongoose);

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,6 +4,7 @@ const { catchErrors } = require("../handlers/errorHandlers");
 
 const postController = require("../controllers/postController");
 const adminController = require("../controllers/adminController");
+const authController = require("../controllers/authController");
 
 /* GET home page. */
 router.get("/", catchErrors(postController.loadIndex));
@@ -27,10 +28,11 @@ router.get("/register", adminController.registerForm);
 router.post(
   "/register",
   // validate registration data
-  adminController.registerAdmin,
+  adminController.validateAdmin,
   // register the user
   adminController.register
   // log the user in
+  //authController.login
 );
 
 module.exports = router;

--- a/views/register.pug
+++ b/views/register.pug
@@ -8,8 +8,6 @@ block content
     input(type="text" name="name")
     label(for="email") Email
     input(type="email" name="email")
-    label(for="email") Username
-    input(type="text" name="username")
     label(for="password") Password
     input(type="password" name="password")
     label(for="password-confirm") Confirm Password


### PR DESCRIPTION
- Makes the email the default username for passport-local-mongoose without needed username field on page. 
- Renamed `registerAdmin` to `validateAdmin`
