### PR TITLE
Rework menus

### DIFF
--- a/controllers/menuController.js
+++ b/controllers/menuController.js
@@ -15,21 +15,19 @@ exports.startNewMenu = async (req, res) => {
 };
 
 // This function creates the Object to send into the database
-// by building the manuItems array from the request
+// by building the menuItems array from the request
 const buildMenuToSave = req => {
   const menuToSave = {
     title: req.body.title,
     menuItems: []
   };
   // Get menu items from request and put them into the menuItems array
-  let currentItem = 1;
-  while (req.body[`${currentItem}-name`]) {
-    menuToSave.menuItems.push({
-      name: req.body[`${currentItem}-name`],
-      url: req.body[`${currentItem}-url`]
-    });
-    currentItem++;
-  }
+  menuToSave.menuItems = req.body.linkName.map((name, i) => {
+    return {
+      name: name,
+      url: req.body.linkUrl[i]
+    };
+  });
   return menuToSave;
 };
 

--- a/controllers/menuController.js
+++ b/controllers/menuController.js
@@ -24,7 +24,7 @@ const buildMenuToSave = req => {
   // Get menu items from request and put them into the menuItems array
   menuToSave.menuItems = req.body.linkName.map((name, i) => {
     return {
-      name: name,
+      name,
       url: req.body.linkUrl[i]
     };
   });

--- a/public/javascripts/adminModules/menuForm.js
+++ b/public/javascripts/adminModules/menuForm.js
@@ -26,28 +26,7 @@ function menuForm(form) {
     inputToShow.querySelector('[data-link-url]').name = 'linkUrl';
   };
 
-  const makeMenu = function() {
-    let menuItems = document.querySelectorAll('.menu-item');
-    let currentItem = 0;
-
-    menuItems.forEach(function(item) {
-      currentItem++;
-      let name = item.querySelector('input[name="linkName"]');
-      let url = item.querySelector('[name="linkUrl"]');
-
-      name.name = `${currentItem}-name`;
-      url.name = `${currentItem}-url`;
-    });
-  };
-
-  const saveMenu = function(e) {
-    e.preventDefault();
-    makeMenu();
-    document.querySelector('#menuForm').submit();
-  };
-
   newMenuBtn.addEventListener('click', addNewMenu);
-  saveMenuBtn.addEventListener('click', saveMenu);
   linkTypeSelects.forEach(select =>
     select.addEventListener('change', changeLinkType)
   );

--- a/views/mixins/_adminMenuForm.pug
+++ b/views/mixins/_adminMenuForm.pug
@@ -100,44 +100,44 @@ mixin menuForm(menu = {})
           div(class='cell small-4 medium-2')
             button(class='button hollow alert expanded remove-menu-item-btn' onClick="this.parentElement.parentElement.remove()") Remove
             hr(class='show-for-small-only')
-
-      //- Hidden empty menu state to copy for new meny items
-      div(class='hide')
-        div(class='cell grid-x grid-margin-x menu-item-new')
-          div(class='cell small-12 medium-5')
-            label(for='item_1_name') Name
-            input(type='text' name='linkName' placeholder='Add a menu name')
-
-          div(class='cell small-12 medium-5 grid-x')
-
-            //- Link type Select
-            div(class='cell small-12 medium-6 large-6 link-type-div')
-              label(for="linkType") Link Type
-              select(name="linkType" class="link-type-select")
-                option(value="external") External Link
-                option(value="post" selected) Post Link
-
-            //- Link input or post selector
-            div(class='cell small-12 medium-6 large-6')
-              div(class='url-select-input' data-link-type data-link-type-post)
-                label(for='item_1_url') Url
-                select(name="linkUrl" data-link-url)
-                  if posts.length
-                    for post in posts
-                      option(value=`/posts/${post.slug}`)= post.title
-                //- By default we want a post link, so we are hiding the text input  in case the link type changes
-              div(class='hide url-hidden-input' data-link-type data-link-type-external)
-                label(for='item_1_url') Url
-                input(type='text' name='' placeholder='Add a menu url' data-link-url)
-
-          div(class='cell small-4 medium-2')
-            button(class='button hollow alert expanded remove-menu-item-btn' onClick="this.parentElement.parentElement.remove()") Remove
-            hr(class='show-for-small-only')
       
     div(class='cell')
       p(class='hollow button secondary add-menu-item' id='addMenuItem') Add menu item 
       input(type='submit' class='button primary')
 
+  
+  //- Hidden empty menu state to copy for new meny items
+  div(class='hide')
+    div(class='cell grid-x grid-margin-x menu-item-new')
+      div(class='cell small-12 medium-5')
+        label(for='item_1_name') Name
+        input(type='text' name='linkName' placeholder='Add a menu name')
+
+      div(class='cell small-12 medium-5 grid-x')
+
+        //- Link type Select
+        div(class='cell small-12 medium-6 large-6 link-type-div')
+          label(for="linkType") Link Type
+          select(name="linkType" class="link-type-select")
+            option(value="external") External Link
+            option(value="post" selected) Post Link
+
+        //- Link input or post selector
+        div(class='cell small-12 medium-6 large-6')
+          div(class='url-select-input' data-link-type data-link-type-post)
+            label(for='item_1_url') Url
+            select(name="linkUrl" data-link-url)
+              if posts.length
+                for post in posts
+                  option(value=`/posts/${post.slug}`)= post.title
+            //- By default we want a post link, so we are hiding the text input  in case the link type changes
+          div(class='hide url-hidden-input' data-link-type data-link-type-external)
+            label(for='item_1_url') Url
+            input(type='text' name='' placeholder='Add a menu url' data-link-url)
+
+      div(class='cell small-4 medium-2')
+        button(class='button hollow alert expanded remove-menu-item-btn' onClick="this.parentElement.parentElement.remove()") Remove
+        hr(class='show-for-small-only')
         
 
 


### PR DESCRIPTION
**This PR:**
- Changes the `buildMenuToSave` function in the menu controller to use `.map()` instead of a while loop. It no longer relies on the input values being numbered on the front end.
- Removes the `makeMenu` function from the front end js file, since it is no longer needed.
- Moves the placeholder menu item in the `_menuForm.pug` file outside the `form` tag, so that it doesn't get sent as part of the request.

This branch is pulled from https://github.com/andrewmcgov/express-cms/pull/65, so we should merge that one first.